### PR TITLE
Add-package-json-with-start-script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.project
+/node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "Linkage",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "Linkage",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "linkage6",
+  "version": "0.0.0",
+  "description": "Robby's Linkage6 Application",
+  "scripts": {
+    "start": "http-server . -p 3000"
+  }
+}


### PR DESCRIPTION
Added a “package.json” file which contains an install of “http-server”, and a “start” script command to run Node’s “http-server . -p 3000” and TADA IT WORKS at URL “http://localhost:3000/”! I have also added a “.gitignore” file to ignore “node_modules” where the “http-server” is installed and ".project" which I need for the IDE that I use.